### PR TITLE
Better Module Support for SugarCRM

### DIFF
--- a/sugarcrm/sugarentry.py
+++ b/sugarcrm/sugarentry.py
@@ -48,8 +48,7 @@ class SugarEntry:
                 else:
                     # Retrieve the field from the SugarCRM connection.
                     
-                    q_str = self._module._name.lower() + \
-                                ".id='%s'" % self['id']
+                    q_str = "%s.id='%s'" % (self._module._table, self['id'])
                     res = self._module._connection.get_entry_list(
                                                     self._module._name, q_str,
                                                     '', 0, [field_name], 1, 0)

--- a/sugarcrm/sugarmodule.py
+++ b/sugarcrm/sugarmodule.py
@@ -25,7 +25,14 @@ class SugarModule:
         result = self._connection.get_module_fields(self._name)
 
         self._fields = result['module_fields']
-        self._relationships = result['link_fields'].copy()
+        
+        # In order to ensure that queries target the correct tables.
+        # Necessary to replace a call to self._name.lower() which
+        # was resulting in broken modules (ProductTemplates, etc).
+        self._table = result['table_name']
+        # If there aren't relationships the result here is an empty list
+        # which has no copy method.  Fixing to provide an empty default.
+        self._relationships = (result['link_fields'] or {}).copy()
 
 
     def _search(self, query_str, start = 0, total = 20, fields = []):


### PR DESCRIPTION
There were several exceptions in Modules.  Some were
related to empty relationships, others were mis-mapped
table names.  In any event, several new modules are now
accessible via the REST API.
