### PR TITLE
Added parentheses around multiple except clauses.

### DIFF
--- a/sugarcrm/sugarcrm.py
+++ b/sugarcrm/sugarcrm.py
@@ -57,7 +57,7 @@ class Sugarcrm:
                     try:
                         result = self._sendRequest(method_name,
                                               [self._session] + list(args))
-                    except SugarError, error:
+                    except (SugarError, error):
                         if error.is_invalid_session():
                             # Try to recover if session ID was lost
                             self._login(self._username, self._password)


### PR DESCRIPTION
The exception handling code on line 60 threw an invalid syntax error when I attempted to compile this in Python 3.3 for Windows.  Placing the parentheses around the except clauses fixed this and works in Python 2.x as well. Sources (http://docs.python.org/3/tutorial/errors.html and http://docs.python.org/2/tutorial/errors.html)   
