### PR TITLE
Use simplejson for JSON encoding/deciding to support decimals.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@
 
 """
 
-import os
 from distutils.core import setup
 
 version = '0.2.0'
@@ -24,4 +23,5 @@ setup(name = 'sugarcrm',
                    "Topic :: Office/Business"],
       keywords="Customer Relationship Management SugarCRM CRM",
       packages=PACKAGES,
+      install_requires=['simplejson>=2.2']
 )

--- a/sugarcrm/sugarcrm.py
+++ b/sugarcrm/sugarcrm.py
@@ -6,9 +6,7 @@
 
 import urllib
 import hashlib
-import json
-import sys
-import re
+import simplejson as json
 
 from sugarerror import SugarError, SugarUnhandledException, is_error
 from sugarmodule import *


### PR DESCRIPTION
This pull request switches the inbuilt `json` module for `simplejson` to support for encoding/deciding Decimal objects. (The flag `use_decimal=True` [isn't required since simplejson 2.2](http://simplejson.readthedocs.org/en/latest/index.html?highlight=use_decimal) so have made that the minimum version in `setup.py`.)

Previously I was getting errors like this:

```
Traceback (most recent call last):
  File "/path/to/my/project/local/lib/python2.7/site-packages/django/core/management/base.py", line 222, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/path/to/my/project/local/lib/python2.7/site-packages/django/core/management/base.py", line 255, in execute
    output = self.handle(*args, **options)
  File "/path/to/my/project/sugarcrm/management/commands/newcontact.py", line 150, in handle
    contact = new_contact(cc3_user_profile, user_profile, connection)
  File "/path/to/my/project/sugarcrm/management/commands/newcontact.py", line 78, in new_contact
    {'name': 'extra_address_c', 'value': profile.extra_address},
  File "/path/to/my/project/src/sugarcrm/sugarcrm/sugarcrm.py", line 61, in f
    [self._session] + list(args))
  File "/path/to/my/project/src/sugarcrm/sugarcrm/sugarcrm.py", line 108, in _sendRequest
    data = json.dumps(data)
  File "/usr/lib/python2.7/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python2.7/json/encoder.py", line 201, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python2.7/json/encoder.py", line 264, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python2.7/json/encoder.py", line 178, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: Decimal('168.000000') is not JSON serializable
```
